### PR TITLE
Fix compilation warnings and errors under GCC 15

### DIFF
--- a/fw/User/error.c
+++ b/fw/User/error.c
@@ -71,7 +71,7 @@ void fatal(char *fmt, ...) {
     syslog_print(line);
 
     // Increase priority of the shell so it becomes the only thing to run
-    vTaskPrioritySet(&startup_task_handle, HIGHEST_PRIORITY);
+    vTaskPrioritySet(startup_task_handle, HIGHEST_PRIORITY);
 
     taskEXIT_CRITICAL();
 

--- a/fw/User/pal_i2c.c
+++ b/fw/User/pal_i2c.c
@@ -22,6 +22,8 @@
 //
 #include "platform.h"
 #include "pal_i2c.h"
+#include "board.h"
+#include "syslog.h"
 
 // Ugly
 #define I2C1_SCL        GPIOB, GPIO_PIN_6

--- a/fw/User/usbpd.c
+++ b/fw/User/usbpd.c
@@ -24,6 +24,8 @@
 #include "board.h"
 #include "app.h"
 #include "wake_event_latch.h"
+#include "usbpd/usb_pd.h"
+#include "usbpd/tcpm.h"
 
 static SemaphoreHandle_t isr_sem = NULL;
 bool dp_ready = false;
@@ -92,10 +94,10 @@ portTASK_FUNCTION(usb_pd_task, pvParameters) {
         BaseType_t rtos_result = xSemaphoreTake(isr_sem, pdMS_TO_TICKS(timeout/1000));
 //        if (rtos_result) {
 //            syslog_printf("FUSB302 interrupt");
-//            //fusb302_tcpc_alert(0);
+//            //tcpc_alert(0);
 //        }
         do {
-            fusb302_tcpc_alert(0);
+            tcpc_alert(0);
             timeout = pd_run_state_machine(0);
             if (!dp_enabled) {
                 hpd_sent = false;

--- a/fw/User/usbpd/usb_pd.h
+++ b/fw/User/usbpd/usb_pd.h
@@ -1440,6 +1440,14 @@ int pd_alt_mode(int port, uint16_t svid);
 void pd_send_hpd(int port, enum hpd_event hpd);
 
 /**
+ * Check if the VDM state machine is currently busy.
+ *
+ * @param port port number.
+ * @return true if VDM is busy, false otherwise.
+ */
+bool pd_is_vdm_busy(int port);
+
+/**
  * Enable USB Billboard Device.
  */
 extern const struct deferred_data pd_usb_billboard_deferred_data;

--- a/fw/User/usbpd/usb_pd_driver.h
+++ b/fw/User/usbpd/usb_pd_driver.h
@@ -28,6 +28,7 @@ extern "C" {
 #endif
 
 #include "usb_pd.h"
+#include "board.h"
 
 #include <stdint.h>
 
@@ -78,8 +79,8 @@ extern "C" {
 
 #define PDO_FIXED_FLAGS (PDO_FIXED_COMM_CAP)
 
-#define usleep(us) (delay_us(us))
-#define msleep(ms) (delay_ms(ms))
+#define usleep(us) (sleep_us(us))
+#define msleep(ms) (sleep_ms(ms))
 
 typedef union {
 	uint64_t val;
@@ -114,6 +115,16 @@ timestamp_t get_time(void);
 	temp_a < temp_b ? temp_a : temp_b;	\
 })
 #endif
+
+/* No-op implementations of Chrome EC hooks and deferred functions */
+#define DECLARE_HOOK(hook, routine, priority)
+#define DECLARE_DEFERRED(routine)
+#define HOOK_PRIO_DEFAULT 0
+#define HOOK_BATTERY_SOC_CHANGE 0
+#define HOOK_CHIPSET_RESUME 0
+#define HOOK_CHIPSET_SUSPEND 0
+#define HOOK_CHIPSET_STARTUP 0
+#define HOOK_CHIPSET_SHUTDOWN 0
 
 #ifdef __cplusplus
 }

--- a/fw/User/usbpd/usb_pd_protocol.c
+++ b/fw/User/usbpd/usb_pd_protocol.c
@@ -3419,10 +3419,10 @@ int pd_run_state_machine(int port)
 
 	/* Check for disconnection if we're connected */
 	if (!pd_is_connected(port))
-		return;
+		return timeout;
 #ifdef CONFIG_USB_PD_DUAL_ROLE
 	if (pd_is_power_swapping(port))
-		return;
+		return timeout;
 #endif
 	if (pd[port].power_role == PD_ROLE_SOURCE) {
 		/* Source: detect disconnect by monitoring CC */


### PR DESCRIPTION
Running on Fedora 44: need these to compile cleanly.
Toolchain: arm-none-eabi-gcc version 15.2.0 (specifically 15.2.0-4.fc44).

GCC 15 defaults to `--std=gnu23` which is stricter. Apart from some textual stuff (includes, missing defines), there were also two maybe real fixes:
  1. `fw/User/error.c`, where a pointer-to-pointer (`&startup_task_handle`, or `TaskHandle_t **`) was incorrectly passed to `vTaskPrioritySet` instead of the handle itself (`startup_task_handle`, or `TaskHandle_t`). 
  2. `fw/User/usbpd/usb_pd_protocol.c`, where `pd_run_state_machine` is defined as returning `int` but had two early exits returning void.
