### PR TITLE
Implement Native Standby Mode and DisplayPort Wakeup Handshake

### DIFF
--- a/fw/User/error.c
+++ b/fw/User/error.c
@@ -71,7 +71,7 @@ void fatal(char *fmt, ...) {
     syslog_print(line);
 
     // Increase priority of the shell so it becomes the only thing to run
-    vTaskPrioritySet(&startup_task_handle, HIGHEST_PRIORITY);
+    vTaskPrioritySet(startup_task_handle, HIGHEST_PRIORITY);
 
     taskEXIT_CRITICAL();
 

--- a/fw/User/pal_i2c.c
+++ b/fw/User/pal_i2c.c
@@ -22,6 +22,8 @@
 //
 #include "platform.h"
 #include "pal_i2c.h"
+#include "board.h"
+#include "syslog.h"
 
 // Ugly
 #define I2C1_SCL        GPIOB, GPIO_PIN_6

--- a/fw/User/ptn3460.c
+++ b/fw/User/ptn3460.c
@@ -61,8 +61,9 @@ void ptn3460_init(void) {
     int ticks = 0;
     while (gpio_get(DP_HPD) != true) {
         ticks ++;
-        if (ticks > 500) {
+        if (ticks >= 500) {
             syslog_printf("PTN3460 boot timeout\n");
+            break;
         }
         sleep_ms(1);
     }

--- a/fw/User/shell/shell.c
+++ b/fw/User/shell/shell.c
@@ -81,6 +81,7 @@ SHELL_FUNC( shell_rm );
 SHELL_FUNC( shell_setvolt );
 SHELL_FUNC( shell_setcfg );
 SHELL_FUNC( shell_sensor );
+SHELL_FUNC( shell_standby );
 
 SHELL_HELP( help );
 SHELL_HELP( ver );
@@ -97,6 +98,7 @@ SHELL_HELP( rm );
 SHELL_HELP( setvolt );
 SHELL_HELP( setcfg );
 SHELL_HELP( sensor );
+SHELL_HELP( standby );
 
 //static const SHELL_COMMAND shell_commands[] =
 const SHELL_COMMAND shell_commands[] =
@@ -116,6 +118,7 @@ const SHELL_COMMAND shell_commands[] =
   { "setvolt", shell_setvolt },
   { "setcfg", shell_setcfg },
   { "sensor", shell_sensor },
+  { "standby", shell_standby },
   { "exit", NULL },
   { NULL, NULL }
 };
@@ -137,6 +140,7 @@ static const SHELL_HELP_DATA shell_help_data[] =
   SHELL_INFO( setvolt ),
   SHELL_INFO( setcfg ),
   SHELL_INFO( sensor ),
+  SHELL_INFO( standby ),
   { NULL, NULL, NULL }
 };
 

--- a/fw/User/shell/shell_cmds.c
+++ b/fw/User/shell/shell_cmds.c
@@ -26,6 +26,7 @@
 #include "app_main.h"
 #include "app.h"
 #include "xmodem.h"
+#include "ui.h"
 
 #ifdef printf
 #undef printf
@@ -767,4 +768,24 @@ void shell_sensor(shell_context_t *ctx, int argc, char **argv) {
     power_get_rail_power(RAIL_5VEG, &p_cur, &p_avg, &p_max);
     p_cur_sum += p_cur; p_avg_sum += p_avg; p_max_sum += p_max;
     printf("EPD HV:    %5.1f mW  %5.1f mW  %5.1f mW\n", p_cur_sum, p_avg_sum, p_max_sum);
+}
+
+const char shell_help_standby[] = "<on|off>\n";
+const char shell_help_summary_standby[] = "Control low-power standby mode";
+
+void shell_standby(shell_context_t *ctx, int argc, char **argv) {
+    if (argc < 2) {
+        printf("Usage: standby <on|off>\n");
+        return;
+    }
+    
+    if (strcmp(argv[1], "on") == 0) {
+        printf("Requesting standby mode...\n");
+        system_standby = true;
+    } else if (strcmp(argv[1], "off") == 0) {
+        printf("Requesting wake-up...\n");
+        system_standby = false;
+    } else {
+        printf("Usage: standby <on|off>\n");
+    }
 }

--- a/fw/User/ui.c
+++ b/fw/User/ui.c
@@ -24,6 +24,11 @@
 #include "board.h"
 #include "app.h"
 #include "ui.h"
+#include "fpga.h"
+#include "caster.h"
+#include "adv7611.h"
+#include "ptn3460.h"
+#include "usbpd/usb_pd.h"
 
 static QueueHandle_t btn_queue;
 
@@ -37,6 +42,8 @@ typedef enum {
 } btn_event_t;
 
 static int mode = 0;
+static bool tmds_mode = false;
+bool system_standby = false;
 
 typedef struct {
     update_mode_t id;
@@ -177,7 +184,7 @@ portTASK_FUNCTION(ui_task, pvParameters) {
     //font_t *font_32x53 = load_font("font_32x53.bin");
 
     // First wait link establish
-    bool tmds_mode = false;
+    tmds_mode = false;
 
     if (config.input_sel == INPUT_SEL_DP) {
         tmds_mode = false;
@@ -221,7 +228,23 @@ portTASK_FUNCTION(ui_task, pvParameters) {
     caster_init(); // Start refresh
     syslog_printf("FPGA started with status %02x", fpga_write_reg8(CSR_STATUS, 0x00));
 
+    bool last_standby = false;
+
     while (1) {
+        if (system_standby) {
+            if (!last_standby) {
+                ui_enter_standby();
+                last_standby = true;
+            }
+            vTaskDelay(pdMS_TO_TICKS(100));
+            continue;
+        } else {
+            if (last_standby) {
+                ui_exit_standby();
+                last_standby = false;
+            }
+        }
+
         // Check OSD timeout
         if ((osd_timeout != 0) && (((int32_t)xTaskGetTickCount() - (int32_t)osd_timeout) >= 0)) {
             osd_timeout = 0;
@@ -351,4 +374,56 @@ portTASK_FUNCTION(key_scan_task, pvParameters) {
         }
         vTaskDelay(pdMS_TO_TICKS(10));
     }
+}
+
+void ui_enter_standby(void) {
+
+    // 1. Power off EPD high voltage rails
+    power_off_epd();
+
+    // 2. Stop FPGA display controller scanning and framebuffer reads
+    fpga_write_reg8(CSR_ENABLE, 0);
+
+    // 3. Power down the active video receiver
+    if (tmds_mode) {
+        adv7611_powerdown();
+    } else {
+        pd_send_hpd(0, hpd_low);
+        ptn3460_powerdown();
+    }
+
+    // 4. Suspend the FPGA (pull SUSPEND high)
+    gpio_put(FPGA_SUSP, 1);
+    
+    syslog_printf("Entered standby mode");
+}
+
+void ui_exit_standby(void) {
+
+    // 1. Resume FPGA from suspend state (pull SUSPEND low)
+    gpio_put(FPGA_SUSP, 0);
+    sleep_ms(10); // Wait for FPGA hardware to wake up
+
+    // 2. Re-enable video decoder
+    if (tmds_mode) {
+        adv7611_init();
+        ptn3460_powerdown();
+    } else {
+        ptn3460_early_init(); // Pull DP_PDN high to power up the chip
+        sleep_ms(50);         // Wait for PTN3460 internal bootloader to finish
+        ptn3460_init();       // Initialize and configure DisplayPort registers
+        pd_send_hpd(0, hpd_high);
+        adv7611_powerdown();
+    }
+
+    // 3. Re-initialize FPGA (reload bitstream + wait for PLL lock)
+    restart_fpga();
+
+    // 4. Power on EPD rails
+    power_on_epd();
+
+    // 5. Re-enable Caster
+    caster_init();
+
+    syslog_printf("Exited standby mode");
 }

--- a/fw/User/ui.c
+++ b/fw/User/ui.c
@@ -424,6 +424,7 @@ void ui_exit_standby(void) {
 
     // 5. Re-enable Caster
     caster_init();
+    caster_setmode(0, 0, config.hact, config.vact, modes[mode].id);
 
     syslog_printf("Exited standby mode");
 }

--- a/fw/User/ui.h
+++ b/fw/User/ui.h
@@ -25,3 +25,7 @@
 void ui_init(void);
 portTASK_FUNCTION(ui_task, pvParameters);
 portTASK_FUNCTION(key_scan_task, pvParameters);
+
+extern bool system_standby;
+void ui_enter_standby(void);
+void ui_exit_standby(void);

--- a/fw/User/usbapp.c
+++ b/fw/User/usbapp.c
@@ -23,6 +23,7 @@
 #include "platform.h"
 #include "app.h"
 #include "tusb.h"
+#include "ui.h"
 
 void usbapp_term_out(char data, void *usr) {
 	tud_cdc_write_char(data);
@@ -123,10 +124,12 @@ void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_
             NVIC_SystemReset();
             break;
         case USBCMD_POWERDOWN:
-            // TODO
+            system_standby = true;
+            retval = 0;
             break;
         case USBCMD_POWERUP:
-            // TODO
+            system_standby = false;
+            retval = 0;
             break;
         case USBCMD_SETINPUT:
             config.input_sel = param;

--- a/fw/User/usbpd.c
+++ b/fw/User/usbpd.c
@@ -59,6 +59,7 @@ portTASK_FUNCTION(usb_pd_task, pvParameters) {
 //            syslog_printf("FUSB302 interrupt");
 //            //tcpc_alert(0);
 //        }
+        int loop_count = 0;
         do {
             tcpc_alert(0);
             timeout = pd_run_state_machine(0);
@@ -68,8 +69,11 @@ portTASK_FUNCTION(usb_pd_task, pvParameters) {
                 hpd_sent = true;
                 dp_ready = true;
             }
-//            vTaskDelay(pdMS_TO_TICKS(5));
-            //xSemaphoreTake(isr_sem, 0); // Clear semaphore
+            loop_count++;
+            if (loop_count > 5) {
+                vTaskDelay(pdMS_TO_TICKS(5));
+                break;
+            }
         } while (gpio_get(TCPC_INT) == 0);
     }
 

--- a/fw/User/usbpd.c
+++ b/fw/User/usbpd.c
@@ -23,6 +23,8 @@
 #include "platform.h"
 #include "board.h"
 #include "app.h"
+#include "usbpd/usb_pd.h"
+#include "usbpd/tcpm.h"
 
 static SemaphoreHandle_t isr_sem = NULL;
 bool dp_ready = false;
@@ -55,10 +57,10 @@ portTASK_FUNCTION(usb_pd_task, pvParameters) {
         BaseType_t rtos_result = xSemaphoreTake(isr_sem, pdMS_TO_TICKS(timeout/1000));
 //        if (rtos_result) {
 //            syslog_printf("FUSB302 interrupt");
-//            //fusb302_tcpc_alert(0);
+//            //tcpc_alert(0);
 //        }
         do {
-            fusb302_tcpc_alert(0);
+            tcpc_alert(0);
             timeout = pd_run_state_machine(0);
             if (dp_enabled && !hpd_sent && !pd_is_vdm_busy(0)) {
                 syslog_printf("DP enabled\n");

--- a/fw/User/usbpd/usb_pd.h
+++ b/fw/User/usbpd/usb_pd.h
@@ -1440,6 +1440,14 @@ int pd_alt_mode(int port, uint16_t svid);
 void pd_send_hpd(int port, enum hpd_event hpd);
 
 /**
+ * Check if the VDM state machine is currently busy.
+ *
+ * @param port port number.
+ * @return true if VDM is busy, false otherwise.
+ */
+bool pd_is_vdm_busy(int port);
+
+/**
  * Enable USB Billboard Device.
  */
 extern const struct deferred_data pd_usb_billboard_deferred_data;

--- a/fw/User/usbpd/usb_pd_driver.h
+++ b/fw/User/usbpd/usb_pd_driver.h
@@ -28,6 +28,7 @@ extern "C" {
 #endif
 
 #include "usb_pd.h"
+#include "board.h"
 
 #include <stdint.h>
 
@@ -78,8 +79,8 @@ extern "C" {
 
 #define PDO_FIXED_FLAGS (PDO_FIXED_COMM_CAP)
 
-#define usleep(us) (delay_us(us))
-#define msleep(ms) (delay_ms(ms))
+#define usleep(us) (sleep_us(us))
+#define msleep(ms) (sleep_ms(ms))
 
 typedef union {
 	uint64_t val;
@@ -114,6 +115,16 @@ timestamp_t get_time(void);
 	temp_a < temp_b ? temp_a : temp_b;	\
 })
 #endif
+
+/* No-op implementations of Chrome EC hooks and deferred functions */
+#define DECLARE_HOOK(hook, routine, priority)
+#define DECLARE_DEFERRED(routine)
+#define HOOK_PRIO_DEFAULT 0
+#define HOOK_BATTERY_SOC_CHANGE 0
+#define HOOK_CHIPSET_RESUME 0
+#define HOOK_CHIPSET_SUSPEND 0
+#define HOOK_CHIPSET_STARTUP 0
+#define HOOK_CHIPSET_SHUTDOWN 0
 
 #ifdef __cplusplus
 }

--- a/fw/User/usbpd/usb_pd_protocol.c
+++ b/fw/User/usbpd/usb_pd_protocol.c
@@ -3419,10 +3419,10 @@ int pd_run_state_machine(int port)
 
 	/* Check for disconnection if we're connected */
 	if (!pd_is_connected(port))
-		return;
+		return timeout;
 #ifdef CONFIG_USB_PD_DUAL_ROLE
 	if (pd_is_power_swapping(port))
-		return;
+		return timeout;
 #endif
 	if (pd[port].power_role == PD_ROLE_SOURCE) {
 		/* Source: detect disconnect by monitoring CC */


### PR DESCRIPTION
This PR implements a native, low-power standby mode for the Glider monitor board, allowing software-directed powerdown and wake-up of the high-voltage EPD rail drivers, the FPGA, and the video decoders. It also addresses a DisplayPort Alt Mode wakeup race condition and protects the real-time kernel from task starvation during power transitions.

> [!NOTE]
> This PR is branched off the GCC 15 compatibility changes in #14. The actual size of the new changes is much smaller than the diff list indicates (comprising only the standby/wakeup state files).

Main changes:

1.  **Asynchronous Standby State Machine**:
    *   Adds `ui_enter_standby()` and `ui_exit_standby()` within the display thread (`ui_task`), enabling clean, non-blocking hardware state transitions.
2.  **DisplayPort Alt Mode HPD signaling via USB-PD**:
    *   Adds `pd_send_hpd(0, hpd_low)` on standby entry and `pd_send_hpd(0, hpd_high)` on standby exit. 
    *   *Why this is needed*: In USB-C Alt Mode, HPD is sent as a Vendor Defined Message (VDM) over the CC lines. Without this, the host laptop assumes the monitor remains active during sleep and fails to perform link training or re-assert the pixel clock on wake-up.
3.  **Control APIs**:
    *   Adds the `standby` command to the serial TTY console shell (`standby <on|off>`).
    *   Exposes the standby/wake-up triggers to USB HID packets via Report ID 5: Command 1 (`USBCMD_POWERDOWN`) and Command 2 (`USBCMD_POWERUP`).

Changes made to fix what seems like bugs, but maybe these are not real... I have to defer to someone more experienced:

1.  **DisplayPort Bridge Wakeup Race Resolution**:
    *   Ensures `DP_PDN` is pulled high to power up the PTN3460 bridge chip, followed by a `50ms` delay to allow the bridge's internal bootloader to finish before we start configuring it over I2C.
2.  **Infinite HPD Loop Timeout Safeguard**:
    *   Replaces the infinite polling loop in `ptn3460_init()` with a `500 ms` timeout `break;`. This prevents the system from locking up and flooding the syslog at millisecond intervals if HPD is not asserted.
3.  **RTOS CPU Starvation Prevention (Stuck Interrupt Guard)**:
    *   Patches the `do-while` loop in `usb_pd_task` (`User/usbpd.c`). If the FUSB302 interrupt pin (`TCPC_INT`) is held low (e.g. because I2C writes failed during a power transition), the loop will yield (`vTaskDelay(5)`) and break after 5 iterations. This prevents 100% CPU lockup and ensures the CDC serial console and other housekeeping tasks remain fully responsive.

