### PR TITLE
fw: wire USB HID power commands to power_suspend and add PTN3460 safeguards

### DIFF
--- a/fw/User/ptn3460.c
+++ b/fw/User/ptn3460.c
@@ -61,6 +61,7 @@ static void ptn3460_load_edid(uint8_t *edid) {
 void ptn3460_early_init(void) {
     ptn_state.mutex = xSemaphoreCreateMutex();
     gpio_put(DP_PDN, 1);
+    sleep_ms(50);
 }
 
 void ptn3460_init(void) {
@@ -72,6 +73,7 @@ void ptn3460_init(void) {
         ticks ++;
         if (ticks > 500) {
             syslog_printf("PTN3460 boot timeout\n");
+            break;
         }
         sleep_ms(1);
     }

--- a/fw/User/usbapp.c
+++ b/fw/User/usbapp.c
@@ -23,6 +23,7 @@
 #include "platform.h"
 #include "app.h"
 #include "tusb.h"
+#include "power.h"
 
 void usbapp_term_out(char data, void *usr) {
 	tud_cdc_write_char(data);
@@ -159,10 +160,12 @@ void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_
             NVIC_SystemReset();
             break;
         case USBCMD_POWERDOWN:
-            // TODO
+            power_suspend(POWER_SUSPEND_USER);
+            retval = 0;
             break;
         case USBCMD_POWERUP:
-            // TODO
+            power_request_resume(POWER_WAKE_USB);
+            retval = 0;
             break;
         case USBCMD_SETINPUT:
             config.input_sel = param;


### PR DESCRIPTION
This PR completes the stubbed USB HID power control commands (`USBCMD_POWERDOWN` and `USBCMD_POWERUP`) in `fw/User/usbapp.c` by wiring them to the new `power_suspend(POWER_SUSPEND_USER)` and `power_request_resume(POWER_WAKE_USB)` APIs.

It also adds two DisplayPort bridge (PTN3460) safeguards:
1. **Bootloader delay**: Adds 50ms delay in `ptn3460_early_init()` to allow the chip's internal bootloader to finish powering up before receiving I2C writes.
2. **Loop timeout break**: Adds `break;` inside the HPD boot timeout condition in `ptn3460_init()` to prevent an infinite loop if HPD fails to assert.

Replaces #15.